### PR TITLE
3.5.14-atlan-1.2.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SRC                   := $(GOPATH)/src/github.com/argoproj/argo-workflows
 # docker image publishing options
 IMAGE_NAMESPACE       ?= quay.io/argoproj
 DEV_IMAGE             ?= $(shell [ `uname -s` = Darwin ] && echo true || echo false)
+TARGET_PLATFORM := $(shell [ `uname -m` = arm64 ] && echo linux/arm64 || echo linux/amd64)
 
 # declares which cluster to import to in case it's not the default name
 K3D_CLUSTER_NAME      ?= k3s-default
@@ -98,7 +99,7 @@ endif
 ALWAYS_OFFLOAD_NODE_STATUS := false
 
 $(info GIT_COMMIT=$(GIT_COMMIT) GIT_BRANCH=$(GIT_BRANCH) GIT_TAG=$(GIT_TAG) GIT_TREE_STATE=$(GIT_TREE_STATE) RELEASE_TAG=$(RELEASE_TAG) DEV_BRANCH=$(DEV_BRANCH) VERSION=$(VERSION))
-$(info KUBECTX=$(KUBECTX) DOCKER_DESKTOP=$(DOCKER_DESKTOP) K3D=$(K3D) DOCKER_PUSH=$(DOCKER_PUSH))
+$(info KUBECTX=$(KUBECTX) DOCKER_DESKTOP=$(DOCKER_DESKTOP) K3D=$(K3D) DOCKER_PUSH=$(DOCKER_PUSH) TARGET_PLATFORM=$(TARGET_PLATFORM))
 $(info RUN_MODE=$(RUN_MODE) PROFILE=$(PROFILE) AUTH_MODE=$(AUTH_MODE) SECURE=$(SECURE) STATIC_FILES=$(STATIC_FILES) ALWAYS_OFFLOAD_NODE_STATUS=$(ALWAYS_OFFLOAD_NODE_STATUS) UPPERIO_DB_DEBUG=$(UPPERIO_DB_DEBUG) LOG_LEVEL=$(LOG_LEVEL) NAMESPACED=$(NAMESPACED))
 
 override LDFLAGS += \
@@ -242,6 +243,7 @@ argoexec-image:
 %-image:
 	[ ! -e dist/$* ] || mv dist/$* .
 	docker buildx build \
+		--platform $(TARGET_PLATFORM) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg GIT_TAG=$(GIT_TAG) \
 		--build-arg GIT_TREE_STATE=$(GIT_TREE_STATE) \

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -101,6 +101,13 @@ If you made changes to the executor, you need to build the image:
 make argoexec-image
 ```
 
+You can use the `TARGET_PLATFORM` environment variable to compile images for specific platforms:
+
+```bash
+# compile for both arm64 and amd64
+make argoexec-image TARGET_PLATFORM=linux/arm64,linux/amd64
+```
+
 To also start the API on <http://localhost:2746>:
 
 ```bash

--- a/pkg/apis/workflow/v1alpha1/validation_utils.go
+++ b/pkg/apis/workflow/v1alpha1/validation_utils.go
@@ -62,10 +62,10 @@ func validateWorkflowFieldNames(names []string, isParamOrArtifact bool) error {
 		if len(errs) != 0 {
 			return fmt.Errorf("[%d].name: '%s' is invalid: %s", i, name, strings.Join(errs, ";"))
 		}
-		_, ok := nameSet[name]
-		if ok {
-			return fmt.Errorf("[%d].name '%s' is not unique", i, name)
-		}
+		// _, ok := nameSet[name]
+		// if ok {
+		// 	return fmt.Errorf("[%d].name '%s' is not unique", i, name)
+		// }
 		nameSet[name] = true
 	}
 	return nil

--- a/ui/src/app/shared/artifacts.ts
+++ b/ui/src/app/shared/artifacts.ts
@@ -59,20 +59,20 @@ export const artifactRepoHasLocation = (ar: ArtifactRepository) => {
     }
 };
 
-export const artifactKey = <A extends Artifact>(a: A) => {
-    if (a.gcs) {
+export function artifactKey<A extends Artifact>(a: A) {
+    if (a.gcs?.key) {
         return a.gcs.key;
-    } else if (a.git) {
+    } else if (a.git?.repo) {
         return a.git.repo + '#' + (a.git.revision || 'HEAD');
-    } else if (a.http) {
+    } else if (a.http?.url) {
         return a.http.url;
-    } else if (a.s3) {
+    } else if (a.s3?.key) {
         return a.s3.key;
-    } else if (a.oss) {
+    } else if (a.oss?.key) {
         return a.oss.key;
     } else if (a.raw) {
         return 'raw';
-    } else if (a.azure) {
+    } else if (a.azure?.blob) {
         return a.azure.blob;
     }
     return 'unknown';

--- a/version.go
+++ b/version.go
@@ -46,7 +46,7 @@ func GetVersion() wfv1.Version {
 			versionStr += "+unknown"
 		}
 	}
-	versionStr = "v3.5.14-atlan-1.1.4"
+	versionStr = "v3.5.14-atlan-1.2.0"
 	return wfv1.Version{
 		Version:      versionStr,
 		BuildDate:    buildDate,

--- a/version.go
+++ b/version.go
@@ -46,7 +46,7 @@ func GetVersion() wfv1.Version {
 			versionStr += "+unknown"
 		}
 	}
-	versionStr = "v3.5.14-atlan-1.2.0"
+	versionStr = "v3.5.14-atlan-1.2.1"
 	return wfv1.Version{
 		Version:      versionStr,
 		BuildDate:    buildDate,

--- a/version.go
+++ b/version.go
@@ -46,7 +46,7 @@ func GetVersion() wfv1.Version {
 			versionStr += "+unknown"
 		}
 	}
-	versionStr = "v3.5.14-atlan-1.2.2"
+	versionStr = "v3.5.14-atlan-1.2.3"
 	return wfv1.Version{
 		Version:      versionStr,
 		BuildDate:    buildDate,

--- a/version.go
+++ b/version.go
@@ -46,7 +46,7 @@ func GetVersion() wfv1.Version {
 			versionStr += "+unknown"
 		}
 	}
-	versionStr = "v3.5.14-atlan-1.2.3"
+	versionStr = "v3.5.14-atlan-1.2.4"
 	return wfv1.Version{
 		Version:      versionStr,
 		BuildDate:    buildDate,

--- a/version.go
+++ b/version.go
@@ -46,7 +46,7 @@ func GetVersion() wfv1.Version {
 			versionStr += "+unknown"
 		}
 	}
-	versionStr = "v3.5.14-atlan-1.2.1"
+	versionStr = "v3.5.14-atlan-1.2.2"
 	return wfv1.Version{
 		Version:      versionStr,
 		BuildDate:    buildDate,

--- a/workflow/artifacts/gcs/gcs.go
+++ b/workflow/artifacts/gcs/gcs.go
@@ -196,6 +196,11 @@ func listByPrefix(client *storage.Client, bucket, prefix, delim string) ([]strin
 		if err != nil {
 			return nil, err
 		}
+		// prefix is a file
+		if attrs.Name == prefix {
+			results = []string{attrs.Name}
+			return results, nil
+		}
 		// skip "folder" path like objects
 		// note that we still download content (including "subfolders")
 		// this is just a consequence of how objects are stored in GCS (no real hierarchy)

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -790,7 +790,7 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 
 	woc := newWorkflowOperationCtx(wf, wfc)
 
-	if !(woc.GetShutdownStrategy().Enabled() && woc.GetShutdownStrategy() == wfv1.ShutdownStrategyTerminate) && !wfc.throttler.Admit(key.(string)) {
+	if (!woc.GetShutdownStrategy().Enabled() || woc.GetShutdownStrategy() != wfv1.ShutdownStrategyTerminate) && !wfc.throttler.Admit(key.(string)) && woc.wf.Status.Phase != wfv1.WorkflowRunning {
 		log.WithField("key", key).Info("Workflow processing has been postponed due to max parallelism limit")
 		if woc.wf.Status.Phase == wfv1.WorkflowUnknown {
 			woc.markWorkflowPhase(ctx, wfv1.WorkflowPending, "Workflow processing has been postponed because too many workflows are already running")

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -1105,8 +1105,8 @@ func (woc *wfOperationCtx) processNodeRetries(node *wfv1.NodeStatus, retryStrate
 		retryOnFailed = false
 		retryOnError = true
 	case wfv1.RetryPolicyOnTransientError:
-		retryOnError = true
 		if (lastChildNode.Phase == wfv1.NodeFailed || lastChildNode.Phase == wfv1.NodeError) && errorsutil.IsTransientErr(errors.InternalError(lastChildNode.Message)) {
+			retryOnError = true
 			retryOnFailed = true
 		}
 	case wfv1.RetryPolicyOnFailure:

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -367,7 +367,6 @@ func (we *WorkflowExecutor) SaveArtifacts(ctx context.Context) (wfv1.Artifacts, 
 	aggregateError := ""
 	for _, art := range we.Template.Outputs.Artifacts {
 		saved, err := we.saveArtifact(ctx, common.MainContainerName, &art)
-
 		if err != nil {
 			aggregateError += err.Error() + "; "
 		}
@@ -380,7 +379,6 @@ func (we *WorkflowExecutor) SaveArtifacts(ctx context.Context) (wfv1.Artifacts, 
 	} else {
 		return artifacts, errors.New(aggregateError)
 	}
-
 }
 
 // save artifact
@@ -914,9 +912,9 @@ func (we *WorkflowExecutor) ReportOutputs(ctx context.Context, artifacts []wfv1.
 func (we *WorkflowExecutor) reportResult(ctx context.Context, result wfv1.NodeResult) error {
 	return retryutil.OnError(wait.Backoff{
 		Duration: time.Second,
-		Factor:   2,
-		Jitter:   0.1,
-		Steps:    5,
+		Factor:   2.0,
+		Jitter:   0.2,
+		Steps:    math.MaxInt32, // effectively infinite retries
 		Cap:      30 * time.Second,
 	}, errorsutil.IsTransientErr, func() error {
 		err := we.upsertTaskResult(ctx, result)
@@ -967,7 +965,6 @@ func (we *WorkflowExecutor) AddAnnotation(ctx context.Context, key, value string
 	}
 	_, err = we.ClientSet.CoreV1().Pods(we.Namespace).Patch(ctx, we.PodName, types.MergePatchType, data, metav1.PatchOptions{})
 	return err
-
 }
 
 // isTarball returns whether or not the file is a tarball
@@ -1267,7 +1264,6 @@ func (we *WorkflowExecutor) monitorProgress(ctx context.Context, progressFile st
 // monitorDeadline checks to see if we exceeded the deadline for the step and
 // terminates the main container if we did
 func (we *WorkflowExecutor) monitorDeadline(ctx context.Context, containerNames []string) {
-
 	deadlineExceeded := make(chan bool, 1)
 	if !we.Deadline.IsZero() {
 		t := time.AfterFunc(time.Until(we.Deadline), func() {

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -863,7 +863,7 @@ func (we *WorkflowExecutor) FinalizeOutput(ctx context.Context) {
 		Duration: time.Second,
 		Factor:   2,
 		Jitter:   0.1,
-		Steps:    5,
+		Steps:    math.MaxInt32, // effectively infinite retries
 		Cap:      30 * time.Second,
 	}, errorsutil.IsTransientErr, func() error {
 		err := we.patchTaskResultLabels(ctx, map[string]string{
@@ -886,7 +886,7 @@ func (we *WorkflowExecutor) InitializeOutput(ctx context.Context) {
 		Duration: time.Second,
 		Factor:   2,
 		Jitter:   0.1,
-		Steps:    5,
+		Steps:    math.MaxInt32, // effectively infinite retries
 		Cap:      30 * time.Second,
 	}, errorsutil.IsTransientErr, func() error {
 		err := we.upsertTaskResult(ctx, wfv1.NodeResult{})


### PR DESCRIPTION
compare to v3.5.14-atlan-1.2.3

we added
- [fix: ui render with empty artifact (](https://github.com/atlanhq/argo-workflows/pull/41/commits/67bf5f6a39ead34ac55c920a7448d95c263eb911)https://github.com/argoproj/argo-workflows/pull/14227[)](https://github.com/atlanhq/argo-workflows/pull/41/commits/67bf5f6a39ead34ac55c920a7448d95c263eb911)
- [fix: retry forevever on task result creation related transient errors. …](https://github.com/atlanhq/argo-workflows/pull/41/commits/189e1911c0d74105db4c7c007c5d1a1b63c834ad)
- [fix: executor workflowtaskresult retry should use the default retry a…](https://github.com/atlanhq/argo-workflows/pull/41/commits/2fef713bebe905d1ac9779c55edb09959aa33115)
- [fix: prevent running workflow throttle by parallelism (](https://github.com/atlanhq/argo-workflows/pull/41/commits/1c199ab8e7a58d83e04ab296462cf481853cc5e0)https://github.com/argoproj/argo-workflows/pull/14606[)](https://github.com/atlanhq/argo-workflows/pull/41/commits/1c199ab8e7a58d83e04ab296462cf481853cc5e0)

read more at https://atlanhq.atlassian.net/wiki/spaces/Apps/pages/794099773/Argo-workflow+version+guide