### PR TITLE
3.5.14 atlan 1.5

### DIFF
--- a/server/workflow/workflow_server.go
+++ b/server/workflow/workflow_server.go
@@ -455,6 +455,8 @@ func (s *workflowServer) RetryWorkflow(ctx context.Context, req *workflowpkg.Wor
 		return nil, sutils.ToStatusError(err, codes.Internal)
 	}
 
+	creator.LabelActor(ctx, wf, creator.ActionRetry)
+
 	wf, err = wfClient.ArgoprojV1alpha1().Workflows(req.Namespace).Update(ctx, wf, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, sutils.ToStatusError(err, codes.Internal)

--- a/server/workflow/workflow_server_test.go
+++ b/server/workflow/workflow_server_test.go
@@ -798,6 +798,7 @@ func TestRetryWorkflow(t *testing.T) {
 	server, ctx := getWorkflowServer()
 	t.Run("Labelled", func(t *testing.T) {
 		retried, err := server.RetryWorkflow(ctx, &workflowpkg.WorkflowRetryRequest{Name: "failed", Namespace: "workflows"})
+		assert.Equal(t, string(creator.ActionRetry), retried.Labels[common.LabelKeyAction])
 		if assert.NoError(t, err) {
 			assert.NotNil(t, retried)
 		}

--- a/version.go
+++ b/version.go
@@ -28,7 +28,7 @@ func ImageTag() string {
 
 // GetVersion returns the version information
 func GetVersion() wfv1.Version {
-	var versionStr = "v3.5.14-atlan-1.4"
+	var versionStr = "v3.5.14-atlan-1.5"
 	return wfv1.Version{
 		Version:      versionStr,
 		BuildDate:    buildDate,

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -458,7 +458,8 @@ func (wfc *WorkflowController) runConfigMapWatcher(stopCh <-chan struct{}) {
 		case event := <-retryWatcher.ResultChan():
 			cm, ok := event.Object.(*apiv1.ConfigMap)
 			if !ok {
-				log.Errorf("invalid config map object received in config watcher. Ignored processing")
+				// TODO
+				// log.Errorf("invalid config map object received in config watcher. Ignored processing")
 				continue
 			}
 			log.Debugf("received config map %s/%s update", cm.Namespace, cm.Name)

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	gosync "sync"
 	"syscall"
@@ -819,6 +820,13 @@ func (wfc *WorkflowController) processNextItem(ctx context.Context) bool {
 		val, ok := annotation["bypass-parallelism"]
 		if ok {
 			bypassParallelism = val
+		}
+	}
+	wfParallelismBypassPattern, _ := os.LookupEnv("WF_PARALLELISM_BYPASS_PATTERN")
+	if wfParallelismBypassPattern != "" {
+		matchWfPattern, _ := regexp.MatchString(wfParallelismBypassPattern, wf.Name)
+		if matchWfPattern {
+			bypassParallelism = "true"
 		}
 	}
 

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -121,7 +121,8 @@ func (d *dagContext) getTaskNode(taskName string) *wfv1.NodeStatus {
 	nodeID := d.taskNodeID(taskName)
 	node, err := d.wf.Status.Nodes.Get(nodeID)
 	if err != nil {
-		log.Warnf("was unable to obtain the node for %s, taskName %s", nodeID, taskName)
+		// TODO
+		// log.Warnf("was unable to obtain the node for %s, taskName %s", nodeID, taskName)
 		return nil
 	}
 	return node

--- a/workflow/creator/creator.go
+++ b/workflow/creator/creator.go
@@ -20,6 +20,7 @@ const (
 	ActionStop      ActionType = "Stop"
 	ActionTerminate ActionType = "Terminate"
 	ActionResume    ActionType = "Resume"
+	ActionRetry     ActionType = "Retry"
 	ActionNone      ActionType = ""
 )
 

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -213,6 +213,7 @@ func (we *WorkflowExecutor) LoadArtifacts(ctx context.Context) error {
 				branch := "master"
 				if art.Git.Revision != "" {
 					branch = art.Git.Revision
+				}
 				if art.Git.Branch != "" {
 					branch = art.Git.Branch
 				}

--- a/workflow/executor/executor.go
+++ b/workflow/executor/executor.go
@@ -211,6 +211,8 @@ func (we *WorkflowExecutor) LoadArtifacts(ctx context.Context) error {
 
 				proceed = true
 				branch := "master"
+				if art.Git.Revision != "" {
+					branch = art.Git.Revision
 				if art.Git.Branch != "" {
 					branch = art.Git.Branch
 				}


### PR DESCRIPTION
[fix: server handle retry action](https://github.com/atlanhq/argo-workflows/commit/b589440c362ac63d76e14e61f05a470e53e3895c) 
[fix: remove noisy log](https://github.com/atlanhq/argo-workflows/commit/be521e5095119659810fa7d0a6aef9adb8dec5b5) 
[feat: env var to bypass parallelism](https://github.com/atlanhq/argo-workflows/commit/b8696da07809cda283f70d7c76314199b67c4c59) 
[fix: make use of both revision and branch in git cache](https://github.com/atlanhq/argo-workflows/commit/81532d586c6b235e49659326e3ab2e51341bfe11) 